### PR TITLE
Make Apps publication contract deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ npm install metanet-apps
 ### Initializing the App Catalog
 
 ```typescript
-import { AppCatalog, DEFAULT_APP_LOOKUP_HOSTS } from 'metanet-apps'
+import {
+  AppCatalog,
+  DEFAULT_APP_LOOKUP_HOSTS,
+  requireAppCatalogBroadcastSuccess
+} from 'metanet-apps'
 
 const catalog = new AppCatalog({
   // Optional parameters:
@@ -37,17 +41,21 @@ const catalog = new AppCatalog({
 
 ```typescript
 const appMetadata = {
-  version: '0.1.0',
+  schema_version: '2.0',
+  app_version: '1.0.0',
   name: 'My Awesome App',
   description: 'This app does amazing things on Metanet',
-  icon: 'https://example.com/icon.png',
+  icon_url: 'https://example.com/icon.png',
+  launch_url: 'https://myapp.example.com/',
   domain: 'myapp.example.com',
   category: 'utility',
   tags: ['tools', 'productivity'],
-  release_date: new Date().toISOString()
+  released_at: new Date().toISOString()
 }
 
-const result = await catalog.publishApp(appMetadata)
+const result = requireAppCatalogBroadcastSuccess(
+  await catalog.publishApp(appMetadata)
+)
 console.log('Published app:', result)
 ```
 
@@ -56,6 +64,9 @@ console.log('Published app:', result)
 ```typescript
 // Find by domain
 const appsByDomain = await catalog.findApps({ domain: 'myapp.example.com' })
+
+// Find one listing directly by immutable outpoint
+const [appByOutpoint] = await catalog.findApps({ outpoint: '<txid>.0' })
 
 // Find by category
 const utilityApps = await catalog.findApps({ category: 'utility' })
@@ -96,7 +107,7 @@ const [myApp] = await catalog.findApps({ domain: 'myapp.example.com' })
 const updatedMetadata = {
   ...myApp.metadata,
   description: 'Updated description',
-  version: '0.2.0', 
+  app_version: '0.2.0',
   changelog: 'Added new features'
 }
 
@@ -125,7 +136,7 @@ new AppCatalog(options: AppCatalogOptions)
 
 #### Methods
 
-- `publishApp(metadata: PublishedAppMetadata, opts?: { wallet?: WalletInterface }): Promise<Transaction | BroadcastResponse | BroadcastFailure>`: Publishes an app to the overlay network
+- `publishApp(metadata: PublishedAppMetadata, opts?: { wallet?: WalletInterface }): Promise<BroadcastResponse | BroadcastFailure>`: Publishes an app to the overlay network. Pass the result to `requireAppCatalogBroadcastSuccess` before displaying success.
 - `updateApp(prev: PublishedApp, newMetadata: PublishedAppMetadata): Promise<BroadcastResponse | BroadcastFailure>`: Updates an existing app listing
 - `removeApp(prev: PublishedApp): Promise<BroadcastResponse | BroadcastFailure>`: Removes an app listing from the overlay network
 - `findApps(query?: AppCatalogQuery, opts?: AppCatalogFindOptions): Promise<PublishedApp[]>`: Searches for apps based on the provided query with support for pagination and sorting. If `opts.hosts` is supplied, it queries and merges those hosts directly.
@@ -139,6 +150,7 @@ Query options for finding apps:
 
 ```typescript
 interface AppCatalogQuery {
+  outpoint?: string
   domain?: string
   publisher?: string // PubKeyHex
   name?: string
@@ -157,24 +169,30 @@ interface AppCatalogQuery {
 Metadata for a published app:
 
 ```typescript
-interface PublishedAppMetadata {
-  version: '0.1.0'
+interface PublishedAppMetadataV2 {
+  schema_version: '2.0'
+  app_version: string
   name: string
   description: string
-  icon: string // URL or UHRP
-  httpURL?: string
-  uhrpURL?: string
+  icon_url: string // HTTPS or UHRP
+  launch_url?: string
+  uhrp_url?: string
   domain: string
   publisher?: string // Automatically set by the library from wallet's identity key
   short_name?: string
   category?: string
   tags?: string[]
-  release_date: string // ISO-8601
+  released_at: string // ISO‑8601
   changelog?: string
   banner_image_url?: string
   screenshot_urls?: string[]
 }
 ```
+
+Legacy v0.1 metadata remains readable and is normalized with
+`normalizeAppMetadata`. New publications should use metadata v2. The protocol
+and canonical signing derivation are exported as `METANET_APPS_PROTOCOL` and
+`METANET_APPS_KEY_ID`; Apps overlays verify key ID `"1"`.
 
 ### `PublishedApp`
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ export default {
 
   // Ignore compiled output
   testPathIgnorePatterns: ['dist/'],
+  modulePathIgnorePatterns: ['<rootDir>/dist/'],
   transform: {
       '^.+\\.test.ts?$': ['ts-jest', { 
         useESM: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metanet-apps",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metanet-apps",
-      "version": "1.0.11",
+      "version": "1.1.0",
       "license": "Open BSV License",
       "dependencies": {
         "@bsv/sdk": "^2.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metanet-apps",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "Publish and find Metanet apps with ease",
   "type": "module",
   "main": "dist/cjs/mod.js",

--- a/src/broadcast.ts
+++ b/src/broadcast.ts
@@ -1,0 +1,26 @@
+import type { BroadcastFailure, BroadcastResponse } from '@bsv/sdk'
+
+export class AppCatalogBroadcastError extends Error {
+  readonly code: string
+  readonly txid?: string
+  readonly details?: object
+
+  constructor (failure: BroadcastFailure) {
+    super(failure.description)
+    this.name = 'AppCatalogBroadcastError'
+    this.code = failure.code
+    this.txid = failure.txid
+    this.details = failure.more
+  }
+}
+
+/**
+ * Convert the SDK's resolved failure object into a thrown error so callers
+ * cannot accidentally present a failed overlay submission as successful.
+ */
+export function requireAppCatalogBroadcastSuccess (
+  result: BroadcastResponse | BroadcastFailure
+): BroadcastResponse {
+  if (result.status === 'error') throw new AppCatalogBroadcastError(result)
+  return result
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,13 @@
+import type { WalletProtocol } from '@bsv/sdk'
+
+/** Canonical wallet protocol used by every Metanet Apps token. */
+export const METANET_APPS_PROTOCOL: WalletProtocol = [1, 'metanet apps']
+
+/** Canonical BRC-42 derivation key used to sign and lock app tokens. */
+export const METANET_APPS_KEY_ID = '1'
+
+export const METANET_APPS_TOPIC = 'tm_apps'
+export const METANET_APPS_LOOKUP_SERVICE = 'ls_apps'
+
+/** Legacy key used by a historical UI release. Only use this to spend/migrate rejected outputs. */
+export const METANET_APPS_LEGACY_KEY_ID = 'default'

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,8 @@
 import type { LookupAnswer, LookupQuestion, OverlayLookupFacilitator } from '@bsv/sdk'
 import { AppCatalog } from './index.js'
+import { requireAppCatalogBroadcastSuccess } from './broadcast.js'
+import { METANET_APPS_KEY_ID, METANET_APPS_PROTOCOL } from './constants.js'
+import { AppMetadataValidationError, normalizeAppMetadata } from './metadata.js'
 
 class MockLookupFacilitator implements OverlayLookupFacilitator {
   readonly calls: Array<{ host: string, question: LookupQuestion, timeout?: number }> = []
@@ -78,5 +81,79 @@ describe('AppCatalog direct host lookup', () => {
         includeBeef: false
       }
     })
+  })
+
+  it('sends direct outpoint queries to the lookup service', async () => {
+    const facilitator = new MockLookupFacilitator({
+      'https://overlay.example': { type: 'output-list', outputs: [] }
+    })
+    const catalog = new AppCatalog({ networkPreset: 'mainnet' })
+
+    await catalog.findApps({ outpoint: `${'a'.repeat(64)}.0` }, {
+      facilitator,
+      hosts: ['https://overlay.example']
+    })
+
+    expect(facilitator.calls[0].question.query).toEqual({ outpoint: `${'a'.repeat(64)}.0` })
+  })
+})
+
+describe('Metanet Apps contract', () => {
+  it('exports the protocol and derivation key used by overlays', () => {
+    expect(METANET_APPS_PROTOCOL).toEqual([1, 'metanet apps'])
+    expect(METANET_APPS_KEY_ID).toBe('1')
+  })
+
+  it('throws a stable error for a resolved SDK broadcast failure', () => {
+    expect(() => requireAppCatalogBroadcastSuccess({
+      status: 'error',
+      code: 'ERR_ALL_HOSTS_REJECTED',
+      description: 'Rejected'
+    })).toThrow(expect.objectContaining({ code: 'ERR_ALL_HOSTS_REJECTED' }))
+  })
+
+  it('normalizes legacy metadata without conflating app and schema versions', () => {
+    const normalized = normalizeAppMetadata({
+      version: '0.1.0',
+      name: 'PaperTrade',
+      description: 'Practice trading.',
+      icon: 'https://papertrade.metanet.app/icon.png',
+      httpURL: 'https://papertrade.metanet.app',
+      domain: 'papertrade.metanet.app',
+      release_date: '2026-07-20T00:00:00Z'
+    })
+
+    expect(normalized.schema_version).toBe('0.1.0')
+    expect(normalized.app_version).toBe('0.1.0')
+    expect(normalized.domain).toBe('papertrade.metanet.app')
+    expect(normalized.launch_url).toBe('https://papertrade.metanet.app/')
+  })
+
+  it('rejects credentials and non-HTTPS launch URLs', () => {
+    expect(() => normalizeAppMetadata({
+      schema_version: '2.0',
+      app_version: '1.0.0',
+      name: 'Unsafe app',
+      description: 'Unsafe URL example.',
+      icon_url: 'https://example.com/icon.png',
+      launch_url: 'http://user:secret@example.com',
+      domain: 'example.com',
+      released_at: '2026-07-20T00:00:00Z'
+    })).toThrow(AppMetadataValidationError)
+  })
+
+  it('requires hostname-only domains and a launch target for metadata v2', () => {
+    const metadata = {
+      schema_version: '2.0',
+      app_version: '1.0.0',
+      name: 'Example',
+      description: 'Example app',
+      icon_url: 'https://example.com/icon.png',
+      domain: 'https://example.com',
+      released_at: '2026-07-20T00:00:00.000Z'
+    } as const
+
+    expect(() => normalizeAppMetadata(metadata)).toThrow(AppMetadataValidationError)
+    expect(() => normalizeAppMetadata({ ...metadata, domain: 'example.com' })).toThrow('launch_url or uhrp_url is required')
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,13 @@ import {
   WalletProtocol
 } from '@bsv/sdk'
 import {
+  METANET_APPS_KEY_ID,
+  METANET_APPS_LOOKUP_SERVICE,
+  METANET_APPS_PROTOCOL,
+  METANET_APPS_TOPIC
+} from './constants.js'
+import { validateAppMetadata } from './metadata.js'
+import {
   AppCatalogFindAcrossHostsResult,
   AppCatalogFindOptions,
   AppCatalogOptions,
@@ -26,11 +33,6 @@ import {
 /* ────────────────────────────────────────────────────────────
  * Constants
  * ────────────────────────────────────────────────────────── */
-const PROTOCOL_ID: WalletProtocol = [1, 'metanet apps']
-const DEFAULT_KEY_ID = '1'
-const DEFAULT_OVERLAY_TOPIC = 'tm_apps'
-const DEFAULT_LOOKUP_SERVICE = 'ls_apps'
-
 export const DEFAULT_APP_LOOKUP_HOSTS = [
   'https://overlay-ap-1.bsvb.tech',
   'https://overlay-eu-1.bsvb.tech',
@@ -60,9 +62,9 @@ export class AppCatalog {
   private broadcaster: TopicBroadcaster | undefined
 
   constructor(opts: AppCatalogOptions) {
-    this.keyID = opts.keyID ?? DEFAULT_KEY_ID
-    this.overlayTopic = opts.overlayTopic ?? DEFAULT_OVERLAY_TOPIC
-    this.overlayService = opts.overlayService ?? DEFAULT_LOOKUP_SERVICE
+    this.keyID = opts.keyID ?? METANET_APPS_KEY_ID
+    this.overlayTopic = opts.overlayTopic ?? METANET_APPS_TOPIC
+    this.overlayService = opts.overlayService ?? METANET_APPS_LOOKUP_SERVICE
     this.wallet = opts.wallet ?? new WalletClient()
     this.networkPreset = opts.networkPreset
     this.acceptDelayedBroadcast = opts.acceptDelayedBroadcast ?? false
@@ -122,9 +124,10 @@ export class AppCatalog {
   async publishApp(
     metadata: PublishedAppMetadata,
     opts: { wallet?: WalletInterface } = {}
-  ): Promise<Transaction | BroadcastResponse | BroadcastFailure> {
+  ): Promise<BroadcastResponse | BroadcastFailure> {
     const wallet = opts.wallet ?? this.wallet
     metadata.publisher = await this.getIdentityKey(wallet)
+    validateAppMetadata(metadata)
 
     // --- 1. Encode metadata as UTF‑8 bytes --------------------------------
     const jsonPayload = JSON.stringify(metadata)
@@ -133,7 +136,7 @@ export class AppCatalog {
     // --- 2. Build PushDrop locking script --------------------------------
     const lockingScript = await new PushDrop(wallet).lock(
       [payloadBytes],
-      PROTOCOL_ID,
+      METANET_APPS_PROTOCOL,
       this.keyID,
       'anyone',
       true
@@ -172,6 +175,8 @@ export class AppCatalog {
     newMetadata: PublishedAppMetadata
   ): Promise<BroadcastResponse | BroadcastFailure> {
     if (!prev.token.beef) throw new Error('App token must contain BEEF to update')
+    newMetadata.publisher = await this.getIdentityKey()
+    validateAppMetadata(newMetadata)
 
     // --- 1. Serialize new metadata --------------------------------------
     const jsonPayload = JSON.stringify(newMetadata)
@@ -180,7 +185,7 @@ export class AppCatalog {
     // --- 2. Build new PushDrop locking script ---------------------------
     const newLockingScript = await new PushDrop(this.wallet).lock(
       [payloadBytes],
-      PROTOCOL_ID,
+      METANET_APPS_PROTOCOL,
       this.keyID,
       'anyone',
       true
@@ -213,7 +218,7 @@ export class AppCatalog {
     if (!signableTransaction) throw new Error('Unable to create update transaction')
 
     // --- 4. Produce unlocking script ------------------------------------
-    const unlocker = pushdrop.unlock(PROTOCOL_ID, this.keyID, 'anyone')
+    const unlocker = pushdrop.unlock(METANET_APPS_PROTOCOL, this.keyID, 'anyone')
     const unlockingScript = await unlocker.sign(
       Transaction.fromBEEF(signableTransaction.tx),
       0
@@ -232,6 +237,56 @@ export class AppCatalog {
     // --- 6. Broadcast through overlay -----------------------------------
     const broadcaster = await this.getBroadcaster()
     return await broadcaster.broadcast(transaction)
+  }
+
+  /**
+   * Spend a token created with a legacy derivation key and replace it with a
+   * token using the catalogue's canonical key. Intended for operator recovery.
+   */
+  async migrateLegacyApp (
+    prev: PublishedApp,
+    metadata: PublishedAppMetadata,
+    legacyKeyID: string
+  ): Promise<BroadcastResponse | BroadcastFailure> {
+    if (!prev.token.beef) throw new Error('App token must contain BEEF to migrate')
+
+    metadata.publisher = await this.getIdentityKey()
+    validateAppMetadata(metadata)
+    const payloadBytes = Utils.toArray(JSON.stringify(metadata), 'utf8')
+    const newLockingScript = await new PushDrop(this.wallet).lock(
+      [payloadBytes],
+      METANET_APPS_PROTOCOL,
+      this.keyID,
+      'anyone',
+      true
+    )
+    const prevOutpoint = `${prev.token.txid}.${prev.token.outputIndex}` as const
+    const { signableTransaction } = await this.wallet.createAction({
+      description: 'AppCatalog - migrate legacy app token',
+      inputBEEF: prev.token.beef,
+      inputs: [{
+        outpoint: prevOutpoint,
+        unlockingScriptLength: 74,
+        inputDescription: 'Spend legacy Metanet App token'
+      }],
+      outputs: [{
+        satoshis: 1,
+        lockingScript: newLockingScript.toHex(),
+        outputDescription: 'Migrated Metanet App token'
+      }],
+      options: { acceptDelayedBroadcast: this.acceptDelayedBroadcast, randomizeOutputs: false }
+    })
+    if (!signableTransaction) throw new Error('Unable to create migration transaction')
+
+    const unlocker = new PushDrop(this.wallet).unlock(METANET_APPS_PROTOCOL, legacyKeyID, 'anyone')
+    const unlockingScript = await unlocker.sign(Transaction.fromBEEF(signableTransaction.tx), 0)
+    const { tx } = await this.wallet.signAction({
+      reference: signableTransaction.reference,
+      spends: { 0: { unlockingScript: unlockingScript.toHex() } }
+    })
+    if (!tx) throw new Error('Unable to finalize migration transaction')
+
+    return await (await this.getBroadcaster()).broadcast(Transaction.fromAtomicBEEF(tx))
   }
 
   /* ──────────────────────────────  Remove  ───────────────────────────── */
@@ -259,7 +314,7 @@ export class AppCatalog {
     })
     if (!signableTransaction) throw new Error('Unable to redeem app token')
 
-    const unlocker = new PushDrop(this.wallet).unlock(PROTOCOL_ID, this.keyID, 'anyone')
+    const unlocker = new PushDrop(this.wallet).unlock(METANET_APPS_PROTOCOL, this.keyID, 'anyone')
     const unlockingScript = await unlocker.sign(Transaction.fromBEEF(signableTransaction.tx), 0)
 
     const { tx } = await this.wallet.signAction({
@@ -434,6 +489,7 @@ export class AppCatalog {
   private buildLookupQuery(query: AppCatalogQuery, includeBeef: boolean): Record<string, unknown> {
     const lookupQuery: Record<string, unknown> = {}
     if (query.domain) lookupQuery.domain = query.domain
+    if (query.outpoint) lookupQuery.outpoint = query.outpoint
     if (query.publisher) lookupQuery.publisher = query.publisher
     if (query.name) lookupQuery.name = query.name
     if (query.category) lookupQuery.category = query.category
@@ -486,3 +542,8 @@ export class AppCatalog {
     return String(err)
   }
 }
+
+export * from './constants.js'
+export * from './broadcast.js'
+export * from './metadata.js'
+export * from './types/index.js'

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,0 +1,177 @@
+import type { NormalizedPublishedAppMetadata, PublishedAppMetadata } from './types/index.js'
+
+export const APP_METADATA_LIMITS = {
+  encodedBytes: 64_000,
+  name: 100,
+  shortName: 40,
+  description: 4_000,
+  changelog: 8_000,
+  category: 60,
+  tag: 40,
+  tags: 20,
+  screenshots: 10,
+  url: 2_048
+} as const
+
+export type AppMetadataValidationCode =
+  | 'ERR_METADATA_INVALID'
+  | 'ERR_METADATA_TOO_LARGE'
+  | 'ERR_METADATA_UNSUPPORTED_SCHEMA'
+  | 'ERR_METADATA_INVALID_URL'
+  | 'ERR_METADATA_INVALID_DOMAIN'
+  | 'ERR_METADATA_FIELD_TOO_LONG'
+  | 'ERR_METADATA_TOO_MANY_ITEMS'
+
+export class AppMetadataValidationError extends Error {
+  constructor (readonly code: AppMetadataValidationCode, message: string) {
+    super(message)
+    this.name = 'AppMetadataValidationError'
+  }
+}
+
+function requiredString (value: unknown, field: string, max: number): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new AppMetadataValidationError('ERR_METADATA_INVALID', `${field} is required`)
+  }
+  const normalized = value.trim()
+  if (normalized.length > max) {
+    throw new AppMetadataValidationError('ERR_METADATA_FIELD_TOO_LONG', `${field} exceeds ${max} characters`)
+  }
+  return normalized
+}
+
+function optionalString (value: unknown, field: string, max: number): string | undefined {
+  if (value === undefined || value === null || value === '') return undefined
+  return requiredString(value, field, max)
+}
+
+function normalizeHttpsUrl (value: unknown, field: string, required = false): string | undefined {
+  const stringValue = required
+    ? requiredString(value, field, APP_METADATA_LIMITS.url)
+    : optionalString(value, field, APP_METADATA_LIMITS.url)
+  if (stringValue === undefined) return undefined
+
+  let parsed: URL
+  try {
+    parsed = new URL(stringValue)
+  } catch {
+    throw new AppMetadataValidationError('ERR_METADATA_INVALID_URL', `${field} must be a valid URL`)
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new AppMetadataValidationError('ERR_METADATA_INVALID_URL', `${field} must use HTTPS`)
+  }
+  if (parsed.username !== '' || parsed.password !== '') {
+    throw new AppMetadataValidationError('ERR_METADATA_INVALID_URL', `${field} must not contain credentials`)
+  }
+  return parsed.toString()
+}
+
+function normalizeAssetUrl (value: unknown, field: string, required = false): string | undefined {
+  const stringValue = required
+    ? requiredString(value, field, APP_METADATA_LIMITS.url)
+    : optionalString(value, field, APP_METADATA_LIMITS.url)
+  if (stringValue === undefined) return undefined
+  if (stringValue.startsWith('uhrp://')) return stringValue
+  return normalizeHttpsUrl(stringValue, field, true)
+}
+
+function normalizeDomain (value: unknown, strictHostnameOnly: boolean): string {
+  const raw = requiredString(value, 'domain', 253).toLowerCase().replace(/\.$/, '')
+  let hostname = raw
+  if (raw.includes('://')) {
+    if (strictHostnameOnly) {
+      throw new AppMetadataValidationError('ERR_METADATA_INVALID_DOMAIN', 'domain must contain only a hostname')
+    }
+    try {
+      const parsed = new URL(raw)
+      if (parsed.pathname !== '/' || parsed.search !== '' || parsed.hash !== '') throw new Error('not hostname only')
+      hostname = parsed.hostname
+    } catch {
+      throw new AppMetadataValidationError('ERR_METADATA_INVALID_DOMAIN', 'domain must be a hostname')
+    }
+  }
+  if (
+    hostname === 'localhost' ||
+    hostname.length > 253 ||
+    !/^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(hostname)
+  ) {
+    throw new AppMetadataValidationError('ERR_METADATA_INVALID_DOMAIN', 'domain must be a valid public hostname')
+  }
+  return hostname
+}
+
+function normalizeTags (value: unknown): string[] {
+  if (value === undefined || value === null) return []
+  if (!Array.isArray(value)) throw new AppMetadataValidationError('ERR_METADATA_INVALID', 'tags must be an array')
+  if (value.length > APP_METADATA_LIMITS.tags) {
+    throw new AppMetadataValidationError('ERR_METADATA_TOO_MANY_ITEMS', `tags may contain at most ${APP_METADATA_LIMITS.tags} items`)
+  }
+  return [...new Set(value.map((tag, index) => requiredString(tag, `tags[${index}]`, APP_METADATA_LIMITS.tag).toLowerCase()))]
+}
+
+function normalizeScreenshots (value: unknown): string[] {
+  if (value === undefined || value === null) return []
+  if (!Array.isArray(value)) throw new AppMetadataValidationError('ERR_METADATA_INVALID', 'screenshots must be an array')
+  if (value.length > APP_METADATA_LIMITS.screenshots) {
+    throw new AppMetadataValidationError('ERR_METADATA_TOO_MANY_ITEMS', `screenshots may contain at most ${APP_METADATA_LIMITS.screenshots} items`)
+  }
+  return value.map((url, index) => normalizeAssetUrl(url, `screenshots[${index}]`, true) as string)
+}
+
+function normalizeDate (value: unknown, field: string): string {
+  const raw = requiredString(value, field, 64)
+  const date = new Date(raw)
+  if (Number.isNaN(date.getTime())) throw new AppMetadataValidationError('ERR_METADATA_INVALID', `${field} must be an ISO-8601 date`)
+  return date.toISOString()
+}
+
+/** Validate legacy or v2 metadata and return one stable normalized shape. */
+export function normalizeAppMetadata (metadata: PublishedAppMetadata): NormalizedPublishedAppMetadata {
+  if (metadata === null || typeof metadata !== 'object') {
+    throw new AppMetadataValidationError('ERR_METADATA_INVALID', 'metadata must be an object')
+  }
+
+  const raw = metadata as unknown as Record<string, unknown>
+  const schemaVersion = raw.schema_version ?? '0.1.0'
+  if (schemaVersion !== '0.1.0' && schemaVersion !== '2.0') {
+    throw new AppMetadataValidationError('ERR_METADATA_UNSUPPORTED_SCHEMA', `Unsupported schema version: ${schemaVersion}`)
+  }
+
+  const launchUrl = normalizeHttpsUrl(raw.launch_url ?? raw.httpURL, 'launch_url')
+  const normalized: NormalizedPublishedAppMetadata = {
+    schema_version: schemaVersion,
+    app_version: requiredString(raw.app_version ?? raw.version, 'app_version', 64),
+    name: requiredString(raw.name, 'name', APP_METADATA_LIMITS.name),
+    description: requiredString(raw.description, 'description', APP_METADATA_LIMITS.description),
+    icon_url: normalizeAssetUrl(raw.icon_url ?? raw.icon, 'icon_url', true) as string,
+    domain: normalizeDomain(raw.domain, schemaVersion === '2.0'),
+    released_at: normalizeDate(raw.released_at ?? raw.release_date, 'released_at'),
+    launch_url: launchUrl,
+    uhrp_url: optionalString(raw.uhrp_url ?? raw.uhrpURL, 'uhrp_url', APP_METADATA_LIMITS.url),
+    publisher: optionalString(raw.publisher, 'publisher', 130),
+    short_name: optionalString(raw.short_name, 'short_name', APP_METADATA_LIMITS.shortName),
+    category: optionalString(raw.category, 'category', APP_METADATA_LIMITS.category),
+    tags: normalizeTags(raw.tags),
+    changelog: optionalString(raw.changelog, 'changelog', APP_METADATA_LIMITS.changelog),
+    banner_image_url: normalizeAssetUrl(raw.banner_image_url, 'banner_image_url'),
+    screenshot_urls: normalizeScreenshots(raw.screenshot_urls),
+    support_url: normalizeHttpsUrl(raw.support_url, 'support_url'),
+    contact_url: normalizeHttpsUrl(raw.contact_url, 'contact_url'),
+    privacy_url: normalizeHttpsUrl(raw.privacy_url, 'privacy_url'),
+    capabilities: normalizeTags(raw.capabilities)
+  }
+
+  if (normalized.launch_url === undefined && normalized.uhrp_url === undefined) {
+    throw new AppMetadataValidationError('ERR_METADATA_INVALID_URL', 'launch_url or uhrp_url is required')
+  }
+
+  const encodedBytes = new TextEncoder().encode(JSON.stringify(metadata)).byteLength
+  if (encodedBytes > APP_METADATA_LIMITS.encodedBytes) {
+    throw new AppMetadataValidationError('ERR_METADATA_TOO_LARGE', `metadata exceeds ${APP_METADATA_LIMITS.encodedBytes} bytes`)
+  }
+  return normalized
+}
+
+export function validateAppMetadata (metadata: PublishedAppMetadata): void {
+  normalizeAppMetadata(metadata)
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,7 @@ export interface AppCatalogOptions {
 }
 
 export interface AppCatalogQuery {
+  outpoint?: string
   domain?: string
   publisher?: string // PubKeyHex
   name?: string
@@ -74,7 +75,7 @@ export interface AppCatalogFindAcrossHostsResult {
  * On‑chain App metadata held inside the PushDrop token’s JSON payload.
  * Only the required fields below are mandatory; the rest are optional.
  */
-export interface PublishedAppMetadata {
+export interface LegacyPublishedAppMetadata {
   version: '0.1.0'
   name: string
   description: string
@@ -90,6 +91,54 @@ export interface PublishedAppMetadata {
   changelog?: string
   banner_image_url?: string
   screenshot_urls?: string[]
+}
+
+export interface PublishedAppMetadataV2 {
+  schema_version: '2.0'
+  app_version: string
+  name: string
+  description: string
+  icon_url: string
+  domain: string
+  released_at: string
+  launch_url?: string
+  uhrp_url?: string
+  publisher?: string
+  short_name?: string
+  category?: string
+  tags?: string[]
+  changelog?: string
+  banner_image_url?: string
+  screenshot_urls?: string[]
+  support_url?: string
+  contact_url?: string
+  privacy_url?: string
+  capabilities?: string[]
+}
+
+export type PublishedAppMetadata = LegacyPublishedAppMetadata | PublishedAppMetadataV2
+
+export interface NormalizedPublishedAppMetadata {
+  schema_version: '0.1.0' | '2.0'
+  app_version: string
+  name: string
+  description: string
+  icon_url: string
+  domain: string
+  released_at: string
+  launch_url?: string
+  uhrp_url?: string
+  publisher?: string
+  short_name?: string
+  category?: string
+  tags: string[]
+  changelog?: string
+  banner_image_url?: string
+  screenshot_urls: string[]
+  support_url?: string
+  contact_url?: string
+  privacy_url?: string
+  capabilities: string[]
 }
 
 export interface PublishedApp {


### PR DESCRIPTION
## Summary\n- export the canonical Apps protocol and signing key ID\n- add metadata v2 validation plus legacy normalization\n- expose stable broadcast failures and direct multi-host/outpoint diagnostics\n- add the legacy-output migration primitive used for PaperTrade recovery\n\n## Verification\n- npm test (8 tests)\n- npm run lint\n- npm run build