### PR TITLE
Repair trusted npm publishing

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -18,16 +18,17 @@ jobs:
       matrix:
         node-version: [20, 22, 24]
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
       with:
         node-version: ${{ matrix.node-version }}
         registry-url: 'https://registry.npmjs.org'
+        package-manager-cache: false
     - run: npm ci
     - run: npm run lint:ci --if-present
     - run: npm run test:coverage --if-present
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@0561704f0f02c16a585d4c7555e57fa2e44cf909 # v5.5.2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage/lcov.info
@@ -40,11 +41,14 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
       with:
         node-version: '24'
         registry-url: 'https://registry.npmjs.org'
+        package-manager-cache: false
+    - name: Pin npm CLI for trusted publishing
+      run: npm install --global npm@11.12.1
     - run: npm ci
     - run: npm run build
     - name: Check if version already published

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "metanet-apps",
   "version": "1.1.0",
   "description": "Publish and find Metanet apps with ease",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bsv-blockchain/metanet-apps.git"
+  },
   "type": "module",
   "main": "dist/cjs/mod.js",
   "module": "dist/esm/mod.js",


### PR DESCRIPTION
Adds the required exact repository identity for npm trusted publishing, pins the release actions by digest, and pins a compatible npm CLI. The 1.1.0 package build and eight tests pass locally.