### PR TITLE
feat: add human-readable publisher metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ interface PublishedAppMetadataV2 {
   uhrp_url?: string
   domain: string
   publisher?: string // Automatically set by the library from wallet's identity key
+  publisher_name?: string // Human-readable publisher or author name
   short_name?: string
   category?: string
   tags?: string[]

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -149,6 +149,7 @@ export function normalizeAppMetadata (metadata: PublishedAppMetadata): Normalize
     launch_url: launchUrl,
     uhrp_url: optionalString(raw.uhrp_url ?? raw.uhrpURL, 'uhrp_url', APP_METADATA_LIMITS.url),
     publisher: optionalString(raw.publisher, 'publisher', 130),
+    publisher_name: optionalString(raw.publisher_name, 'publisher_name', APP_METADATA_LIMITS.name),
     short_name: optionalString(raw.short_name, 'short_name', APP_METADATA_LIMITS.shortName),
     category: optionalString(raw.category, 'category', APP_METADATA_LIMITS.category),
     tags: normalizeTags(raw.tags),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -84,6 +84,7 @@ export interface LegacyPublishedAppMetadata {
   uhrpURL?: string
   domain: string
   publisher?: string // Automatically set by the library
+  publisher_name?: string
   short_name?: string
   category?: string
   tags?: string[]
@@ -104,6 +105,7 @@ export interface PublishedAppMetadataV2 {
   launch_url?: string
   uhrp_url?: string
   publisher?: string
+  publisher_name?: string
   short_name?: string
   category?: string
   tags?: string[]
@@ -129,6 +131,7 @@ export interface NormalizedPublishedAppMetadata {
   launch_url?: string
   uhrp_url?: string
   publisher?: string
+  publisher_name?: string
   short_name?: string
   category?: string
   tags: string[]


### PR DESCRIPTION
Adds the optional metadata v2 publisher_name field so catalogue cards can display a human-readable author without overloading the cryptographic publisher identity key.\n\nValidated with the full package build and test suite.