### PR TITLE
Restore the canonical Metanet Apps v0.1 contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,15 @@ const catalog = new AppCatalog({
 
 ```typescript
 const appMetadata = {
-  schema_version: '2.0',
-  app_version: '1.0.0',
+  version: '0.1.0',
   name: 'My Awesome App',
   description: 'This app does amazing things on Metanet',
-  icon_url: 'https://example.com/icon.png',
-  launch_url: 'https://myapp.example.com/',
+  icon: 'https://example.com/icon.png',
+  httpURL: 'https://myapp.example.com/',
   domain: 'myapp.example.com',
   category: 'utility',
   tags: ['tools', 'productivity'],
-  released_at: new Date().toISOString()
+  release_date: new Date().toISOString()
 }
 
 const result = requireAppCatalogBroadcastSuccess(
@@ -107,7 +106,6 @@ const [myApp] = await catalog.findApps({ domain: 'myapp.example.com' })
 const updatedMetadata = {
   ...myApp.metadata,
   description: 'Updated description',
-  app_version: '0.2.0',
   changelog: 'Added new features'
 }
 
@@ -169,31 +167,31 @@ interface AppCatalogQuery {
 Metadata for a published app:
 
 ```typescript
-interface PublishedAppMetadataV2 {
-  schema_version: '2.0'
-  app_version: string
+interface PublishedAppMetadata {
+  version: '0.1.0'
   name: string
   description: string
-  icon_url: string // HTTPS or UHRP
-  launch_url?: string
-  uhrp_url?: string
+  icon: string // URL or UHRP
+  httpURL?: string
+  uhrpURL?: string
   domain: string
   publisher?: string // Automatically set by the library from wallet's identity key
-  publisher_name?: string // Human-readable publisher or author name
   short_name?: string
   category?: string
   tags?: string[]
-  released_at: string // ISO‑8601
+  release_date: string // ISO‑8601
   changelog?: string
   banner_image_url?: string
   screenshot_urls?: string[]
 }
 ```
 
-Legacy v0.1 metadata remains readable and is normalized with
-`normalizeAppMetadata`. New publications should use metadata v2. The protocol
-and canonical signing derivation are exported as `METANET_APPS_PROTOCOL` and
-`METANET_APPS_KEY_ID`; Apps overlays verify key ID `"1"`.
+The v0.1 shape is the canonical Apps metadata contract. Publisher names and
+profiles are resolved from the `publisher` identity key through BRC-100
+identity discovery and selectively disclosed certificates; they are not copied
+into app metadata. The protocol and canonical signing derivation are exported
+as `METANET_APPS_PROTOCOL` and `METANET_APPS_KEY_ID`; Apps overlays verify key
+ID `"1"`.
 
 ### `PublishedApp`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metanet-apps",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metanet-apps",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Open BSV License",
       "dependencies": {
         "@bsv/sdk": "^2.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metanet-apps",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Publish and find Metanet apps with ease",
   "repository": {
     "type": "git",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,3 @@ export const METANET_APPS_KEY_ID = '1'
 
 export const METANET_APPS_TOPIC = 'tm_apps'
 export const METANET_APPS_LOOKUP_SERVICE = 'ls_apps'
-
-/** Legacy key used by a historical UI release. Only use this to spend/migrate rejected outputs. */
-export const METANET_APPS_LEGACY_KEY_ID = 'default'

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -112,7 +112,7 @@ describe('Metanet Apps contract', () => {
     })).toThrow(expect.objectContaining({ code: 'ERR_ALL_HOSTS_REJECTED' }))
   })
 
-  it('normalizes legacy metadata without conflating app and schema versions', () => {
+  it('accepts canonical v0.1 metadata without rewriting publisher data', () => {
     const normalized = normalizeAppMetadata({
       version: '0.1.0',
       name: 'PaperTrade',
@@ -123,13 +123,12 @@ describe('Metanet Apps contract', () => {
       release_date: '2026-07-20T00:00:00Z'
     })
 
-    expect(normalized.schema_version).toBe('0.1.0')
-    expect(normalized.app_version).toBe('0.1.0')
+    expect(normalized.version).toBe('0.1.0')
     expect(normalized.domain).toBe('papertrade.metanet.app')
-    expect(normalized.launch_url).toBe('https://papertrade.metanet.app/')
+    expect(normalized.httpURL).toBe('https://papertrade.metanet.app')
   })
 
-  it('rejects credentials and non-HTTPS launch URLs', () => {
+  it('rejects noncanonical metadata v2', () => {
     expect(() => normalizeAppMetadata({
       schema_version: '2.0',
       app_version: '1.0.0',
@@ -139,21 +138,20 @@ describe('Metanet Apps contract', () => {
       launch_url: 'http://user:secret@example.com',
       domain: 'example.com',
       released_at: '2026-07-20T00:00:00Z'
-    })).toThrow(AppMetadataValidationError)
+    } as never)).toThrow(expect.objectContaining({ code: 'ERR_METADATA_UNSUPPORTED_SCHEMA' }))
   })
 
-  it('requires hostname-only domains and a launch target for metadata v2', () => {
+  it('mirrors the canonical topic required fields', () => {
     const metadata = {
-      schema_version: '2.0',
-      app_version: '1.0.0',
+      version: '0.1.0',
       name: 'Example',
       description: 'Example app',
-      icon_url: 'https://example.com/icon.png',
-      domain: 'https://example.com',
-      released_at: '2026-07-20T00:00:00.000Z'
+      icon: 'https://example.com/icon.png',
+      domain: 'example.com',
+      release_date: '2026-07-20T00:00:00.000Z'
     } as const
 
-    expect(() => normalizeAppMetadata(metadata)).toThrow(AppMetadataValidationError)
-    expect(() => normalizeAppMetadata({ ...metadata, domain: 'example.com' })).toThrow('launch_url or uhrp_url is required')
+    expect(() => normalizeAppMetadata(metadata as never)).toThrow(AppMetadataValidationError)
+    expect(normalizeAppMetadata({ ...metadata, httpURL: '' })).toEqual({ ...metadata, httpURL: '' })
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,56 +239,6 @@ export class AppCatalog {
     return await broadcaster.broadcast(transaction)
   }
 
-  /**
-   * Spend a token created with a legacy derivation key and replace it with a
-   * token using the catalogue's canonical key. Intended for operator recovery.
-   */
-  async migrateLegacyApp (
-    prev: PublishedApp,
-    metadata: PublishedAppMetadata,
-    legacyKeyID: string
-  ): Promise<BroadcastResponse | BroadcastFailure> {
-    if (!prev.token.beef) throw new Error('App token must contain BEEF to migrate')
-
-    metadata.publisher = await this.getIdentityKey()
-    validateAppMetadata(metadata)
-    const payloadBytes = Utils.toArray(JSON.stringify(metadata), 'utf8')
-    const newLockingScript = await new PushDrop(this.wallet).lock(
-      [payloadBytes],
-      METANET_APPS_PROTOCOL,
-      this.keyID,
-      'anyone',
-      true
-    )
-    const prevOutpoint = `${prev.token.txid}.${prev.token.outputIndex}` as const
-    const { signableTransaction } = await this.wallet.createAction({
-      description: 'AppCatalog - migrate legacy app token',
-      inputBEEF: prev.token.beef,
-      inputs: [{
-        outpoint: prevOutpoint,
-        unlockingScriptLength: 74,
-        inputDescription: 'Spend legacy Metanet App token'
-      }],
-      outputs: [{
-        satoshis: 1,
-        lockingScript: newLockingScript.toHex(),
-        outputDescription: 'Migrated Metanet App token'
-      }],
-      options: { acceptDelayedBroadcast: this.acceptDelayedBroadcast, randomizeOutputs: false }
-    })
-    if (!signableTransaction) throw new Error('Unable to create migration transaction')
-
-    const unlocker = new PushDrop(this.wallet).unlock(METANET_APPS_PROTOCOL, legacyKeyID, 'anyone')
-    const unlockingScript = await unlocker.sign(Transaction.fromBEEF(signableTransaction.tx), 0)
-    const { tx } = await this.wallet.signAction({
-      reference: signableTransaction.reference,
-      spends: { 0: { unlockingScript: unlockingScript.toHex() } }
-    })
-    if (!tx) throw new Error('Unable to finalize migration transaction')
-
-    return await (await this.getBroadcaster()).broadcast(Transaction.fromAtomicBEEF(tx))
-  }
-
   /* ──────────────────────────────  Remove  ───────────────────────────── */
   /**
    * Removes an app listing from the overlay by spending its previous PushDrop output.

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,26 +1,8 @@
-import type { NormalizedPublishedAppMetadata, PublishedAppMetadata } from './types/index.js'
-
-export const APP_METADATA_LIMITS = {
-  encodedBytes: 64_000,
-  name: 100,
-  shortName: 40,
-  description: 4_000,
-  changelog: 8_000,
-  category: 60,
-  tag: 40,
-  tags: 20,
-  screenshots: 10,
-  url: 2_048
-} as const
+import type { PublishedAppMetadata } from './types/index.js'
 
 export type AppMetadataValidationCode =
   | 'ERR_METADATA_INVALID'
-  | 'ERR_METADATA_TOO_LARGE'
   | 'ERR_METADATA_UNSUPPORTED_SCHEMA'
-  | 'ERR_METADATA_INVALID_URL'
-  | 'ERR_METADATA_INVALID_DOMAIN'
-  | 'ERR_METADATA_FIELD_TOO_LONG'
-  | 'ERR_METADATA_TOO_MANY_ITEMS'
 
 export class AppMetadataValidationError extends Error {
   constructor (readonly code: AppMetadataValidationCode, message: string) {
@@ -29,148 +11,62 @@ export class AppMetadataValidationError extends Error {
   }
 }
 
-function requiredString (value: unknown, field: string, max: number): string {
-  if (typeof value !== 'string' || value.trim() === '') {
-    throw new AppMetadataValidationError('ERR_METADATA_INVALID', `${field} is required`)
+function requireString (value: unknown, field: string): asserts value is string {
+  if (typeof value !== 'string') {
+    throw new AppMetadataValidationError('ERR_METADATA_INVALID', `${field} must be a string`)
   }
-  const normalized = value.trim()
-  if (normalized.length > max) {
-    throw new AppMetadataValidationError('ERR_METADATA_FIELD_TOO_LONG', `${field} exceeds ${max} characters`)
-  }
-  return normalized
 }
 
-function optionalString (value: unknown, field: string, max: number): string | undefined {
-  if (value === undefined || value === null || value === '') return undefined
-  return requiredString(value, field, max)
+function optionalString (value: unknown, field: string): void {
+  if (value !== undefined) requireString(value, field)
 }
 
-function normalizeHttpsUrl (value: unknown, field: string, required = false): string | undefined {
-  const stringValue = required
-    ? requiredString(value, field, APP_METADATA_LIMITS.url)
-    : optionalString(value, field, APP_METADATA_LIMITS.url)
-  if (stringValue === undefined) return undefined
-
-  let parsed: URL
-  try {
-    parsed = new URL(stringValue)
-  } catch {
-    throw new AppMetadataValidationError('ERR_METADATA_INVALID_URL', `${field} must be a valid URL`)
+function optionalStringArray (value: unknown, field: string): void {
+  if (value === undefined) return
+  if (!Array.isArray(value) || value.some(item => typeof item !== 'string')) {
+    throw new AppMetadataValidationError('ERR_METADATA_INVALID', `${field} must be an array of strings`)
   }
-  if (parsed.protocol !== 'https:') {
-    throw new AppMetadataValidationError('ERR_METADATA_INVALID_URL', `${field} must use HTTPS`)
-  }
-  if (parsed.username !== '' || parsed.password !== '') {
-    throw new AppMetadataValidationError('ERR_METADATA_INVALID_URL', `${field} must not contain credentials`)
-  }
-  return parsed.toString()
 }
 
-function normalizeAssetUrl (value: unknown, field: string, required = false): string | undefined {
-  const stringValue = required
-    ? requiredString(value, field, APP_METADATA_LIMITS.url)
-    : optionalString(value, field, APP_METADATA_LIMITS.url)
-  if (stringValue === undefined) return undefined
-  if (stringValue.startsWith('uhrp://')) return stringValue
-  return normalizeHttpsUrl(stringValue, field, true)
-}
-
-function normalizeDomain (value: unknown, strictHostnameOnly: boolean): string {
-  const raw = requiredString(value, 'domain', 253).toLowerCase().replace(/\.$/, '')
-  let hostname = raw
-  if (raw.includes('://')) {
-    if (strictHostnameOnly) {
-      throw new AppMetadataValidationError('ERR_METADATA_INVALID_DOMAIN', 'domain must contain only a hostname')
-    }
-    try {
-      const parsed = new URL(raw)
-      if (parsed.pathname !== '/' || parsed.search !== '' || parsed.hash !== '') throw new Error('not hostname only')
-      hostname = parsed.hostname
-    } catch {
-      throw new AppMetadataValidationError('ERR_METADATA_INVALID_DOMAIN', 'domain must be a hostname')
-    }
-  }
-  if (
-    hostname === 'localhost' ||
-    hostname.length > 253 ||
-    !/^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(hostname)
-  ) {
-    throw new AppMetadataValidationError('ERR_METADATA_INVALID_DOMAIN', 'domain must be a valid public hostname')
-  }
-  return hostname
-}
-
-function normalizeTags (value: unknown): string[] {
-  if (value === undefined || value === null) return []
-  if (!Array.isArray(value)) throw new AppMetadataValidationError('ERR_METADATA_INVALID', 'tags must be an array')
-  if (value.length > APP_METADATA_LIMITS.tags) {
-    throw new AppMetadataValidationError('ERR_METADATA_TOO_MANY_ITEMS', `tags may contain at most ${APP_METADATA_LIMITS.tags} items`)
-  }
-  return [...new Set(value.map((tag, index) => requiredString(tag, `tags[${index}]`, APP_METADATA_LIMITS.tag).toLowerCase()))]
-}
-
-function normalizeScreenshots (value: unknown): string[] {
-  if (value === undefined || value === null) return []
-  if (!Array.isArray(value)) throw new AppMetadataValidationError('ERR_METADATA_INVALID', 'screenshots must be an array')
-  if (value.length > APP_METADATA_LIMITS.screenshots) {
-    throw new AppMetadataValidationError('ERR_METADATA_TOO_MANY_ITEMS', `screenshots may contain at most ${APP_METADATA_LIMITS.screenshots} items`)
-  }
-  return value.map((url, index) => normalizeAssetUrl(url, `screenshots[${index}]`, true) as string)
-}
-
-function normalizeDate (value: unknown, field: string): string {
-  const raw = requiredString(value, field, 64)
-  const date = new Date(raw)
-  if (Number.isNaN(date.getTime())) throw new AppMetadataValidationError('ERR_METADATA_INVALID', `${field} must be an ISO-8601 date`)
-  return date.toISOString()
-}
-
-/** Validate legacy or v2 metadata and return one stable normalized shape. */
-export function normalizeAppMetadata (metadata: PublishedAppMetadata): NormalizedPublishedAppMetadata {
+/**
+ * Validate the canonical Metanet Apps v0.1 metadata shape.
+ *
+ * This intentionally mirrors the Apps topic manager. It does not rewrite
+ * domains, URLs, dates, or assets: metadata admitted by the canonical overlay
+ * remains valid and byte-for-byte application data stays under publisher
+ * control.
+ */
+export function normalizeAppMetadata (metadata: PublishedAppMetadata): PublishedAppMetadata {
   if (metadata === null || typeof metadata !== 'object') {
     throw new AppMetadataValidationError('ERR_METADATA_INVALID', 'metadata must be an object')
   }
 
   const raw = metadata as unknown as Record<string, unknown>
-  const schemaVersion = raw.schema_version ?? '0.1.0'
-  if (schemaVersion !== '0.1.0' && schemaVersion !== '2.0') {
-    throw new AppMetadataValidationError('ERR_METADATA_UNSUPPORTED_SCHEMA', `Unsupported schema version: ${schemaVersion}`)
+  if (raw.version !== '0.1.0') {
+    throw new AppMetadataValidationError('ERR_METADATA_UNSUPPORTED_SCHEMA', 'version must be 0.1.0')
   }
 
-  const launchUrl = normalizeHttpsUrl(raw.launch_url ?? raw.httpURL, 'launch_url')
-  const normalized: NormalizedPublishedAppMetadata = {
-    schema_version: schemaVersion,
-    app_version: requiredString(raw.app_version ?? raw.version, 'app_version', 64),
-    name: requiredString(raw.name, 'name', APP_METADATA_LIMITS.name),
-    description: requiredString(raw.description, 'description', APP_METADATA_LIMITS.description),
-    icon_url: normalizeAssetUrl(raw.icon_url ?? raw.icon, 'icon_url', true) as string,
-    domain: normalizeDomain(raw.domain, schemaVersion === '2.0'),
-    released_at: normalizeDate(raw.released_at ?? raw.release_date, 'released_at'),
-    launch_url: launchUrl,
-    uhrp_url: optionalString(raw.uhrp_url ?? raw.uhrpURL, 'uhrp_url', APP_METADATA_LIMITS.url),
-    publisher: optionalString(raw.publisher, 'publisher', 130),
-    publisher_name: optionalString(raw.publisher_name, 'publisher_name', APP_METADATA_LIMITS.name),
-    short_name: optionalString(raw.short_name, 'short_name', APP_METADATA_LIMITS.shortName),
-    category: optionalString(raw.category, 'category', APP_METADATA_LIMITS.category),
-    tags: normalizeTags(raw.tags),
-    changelog: optionalString(raw.changelog, 'changelog', APP_METADATA_LIMITS.changelog),
-    banner_image_url: normalizeAssetUrl(raw.banner_image_url, 'banner_image_url'),
-    screenshot_urls: normalizeScreenshots(raw.screenshot_urls),
-    support_url: normalizeHttpsUrl(raw.support_url, 'support_url'),
-    contact_url: normalizeHttpsUrl(raw.contact_url, 'contact_url'),
-    privacy_url: normalizeHttpsUrl(raw.privacy_url, 'privacy_url'),
-    capabilities: normalizeTags(raw.capabilities)
+  requireString(raw.name, 'name')
+  requireString(raw.description, 'description')
+  requireString(raw.icon, 'icon')
+  requireString(raw.domain, 'domain')
+  requireString(raw.release_date, 'release_date')
+  optionalString(raw.publisher, 'publisher')
+
+  if (typeof raw.httpURL !== 'string' && typeof raw.uhrpURL !== 'string') {
+    throw new AppMetadataValidationError('ERR_METADATA_INVALID', 'httpURL or uhrpURL must be a string')
   }
 
-  if (normalized.launch_url === undefined && normalized.uhrp_url === undefined) {
-    throw new AppMetadataValidationError('ERR_METADATA_INVALID_URL', 'launch_url or uhrp_url is required')
-  }
+  optionalString(raw.httpURL, 'httpURL')
+  optionalString(raw.uhrpURL, 'uhrpURL')
+  optionalString(raw.short_name, 'short_name')
+  optionalString(raw.category, 'category')
+  optionalString(raw.changelog, 'changelog')
+  optionalString(raw.banner_image_url, 'banner_image_url')
+  optionalStringArray(raw.tags, 'tags')
+  optionalStringArray(raw.screenshot_urls, 'screenshot_urls')
 
-  const encodedBytes = new TextEncoder().encode(JSON.stringify(metadata)).byteLength
-  if (encodedBytes > APP_METADATA_LIMITS.encodedBytes) {
-    throw new AppMetadataValidationError('ERR_METADATA_TOO_LARGE', `metadata exceeds ${APP_METADATA_LIMITS.encodedBytes} bytes`)
-  }
-  return normalized
+  return { ...metadata }
 }
 
 export function validateAppMetadata (metadata: PublishedAppMetadata): void {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -75,7 +75,7 @@ export interface AppCatalogFindAcrossHostsResult {
  * On‑chain App metadata held inside the PushDrop token’s JSON payload.
  * Only the required fields below are mandatory; the rest are optional.
  */
-export interface LegacyPublishedAppMetadata {
+export interface PublishedAppMetadata {
   version: '0.1.0'
   name: string
   description: string
@@ -84,7 +84,6 @@ export interface LegacyPublishedAppMetadata {
   uhrpURL?: string
   domain: string
   publisher?: string // Automatically set by the library
-  publisher_name?: string
   short_name?: string
   category?: string
   tags?: string[]
@@ -92,56 +91,6 @@ export interface LegacyPublishedAppMetadata {
   changelog?: string
   banner_image_url?: string
   screenshot_urls?: string[]
-}
-
-export interface PublishedAppMetadataV2 {
-  schema_version: '2.0'
-  app_version: string
-  name: string
-  description: string
-  icon_url: string
-  domain: string
-  released_at: string
-  launch_url?: string
-  uhrp_url?: string
-  publisher?: string
-  publisher_name?: string
-  short_name?: string
-  category?: string
-  tags?: string[]
-  changelog?: string
-  banner_image_url?: string
-  screenshot_urls?: string[]
-  support_url?: string
-  contact_url?: string
-  privacy_url?: string
-  capabilities?: string[]
-}
-
-export type PublishedAppMetadata = LegacyPublishedAppMetadata | PublishedAppMetadataV2
-
-export interface NormalizedPublishedAppMetadata {
-  schema_version: '0.1.0' | '2.0'
-  app_version: string
-  name: string
-  description: string
-  icon_url: string
-  domain: string
-  released_at: string
-  launch_url?: string
-  uhrp_url?: string
-  publisher?: string
-  publisher_name?: string
-  short_name?: string
-  category?: string
-  tags: string[]
-  changelog?: string
-  banner_image_url?: string
-  screenshot_urls: string[]
-  support_url?: string
-  contact_url?: string
-  privacy_url?: string
-  capabilities: string[]
 }
 
 export interface PublishedApp {


### PR DESCRIPTION
## What changed

- makes the established v0.1 metadata shape the sole writable Apps contract
- removes metadata v2, publisher_name, the legacy key constant, and incident migration API
- keeps canonical protocol/key constants plus reliable broadcast and multi-host lookup behavior
- validates without rewriting domains, URLs, dates, or publisher-controlled metadata
- prepares corrective package version 1.1.1

## Why

The Apps topic in @bsv/overlay-topics already defines v0.1 as canonical. The 1.1.0 GitHub release introduced a second schema and incident-specific migration API that do not belong in the protocol client.

## Validation

- npm test
- npm run lint:ci